### PR TITLE
chore.: Update GA site coordinators.

### DIFF
--- a/amp_scz_launch/production_pronet_site_configs/PronetGA.sh
+++ b/amp_scz_launch/production_pronet_site_configs/PronetGA.sh
@@ -29,7 +29,7 @@ export auto_send_limit_bool
 # first addresses for the more thorough updates on most recent files
 lab_email_list="philip.wolff@yale.edu,jtbaker@partners.org"
 # then addresses to send the site review notification to
-site_email_list="zarina.bilgrami@emory.edu,Sydney.Howie@uga.edu,SierraAnn.Jarvis@uga.edu,Delaney.Collins@uga.edu"
+site_email_list="zarina.bilgrami@emory.edu,Sydney.Howie@uga.edu,lauren.jennings1@uga.edu,zhixin.zhang@uga.edu,zach.carter@uga.edu"
 # finally should also supply current server label (mainly for dev versus prod)
 server_version="Production"
 # for U24 now have language marker setting to add to the files that are uploaded to TranscribeMe, to alert them of what language the audio will be in


### PR DESCRIPTION
Sierra, Delaney, and Sydney James are no longer working on the GA study. The new coordinators are:

Lauren Jennings – lauren.jennings1 [at] uga.edu
Zhixin Zhang – zhixin.zhang [at] uga.edu
Zach Carter – zach.carter [at] uga.edu